### PR TITLE
use file.path consistently

### DIFF
--- a/R/build_site.R
+++ b/R/build_site.R
@@ -15,14 +15,14 @@
 #' json <- write_json(biblio, access, attributes, creators)
 #' build_site(json)
 #' }
-build_site <- function(path = "data/metadata/dataspice.json",
+build_site <- function(path = file.path("data", "metadata", "dataspice.json"),
                        template_path = system.file("template.html5",
                                                    package = "dataspice"),
-                       out_path = "docs/index.html") {
+                       out_path = file.path("docs", "index.html")) {
   data <- jsonld_to_mustache(path)
 
     # Make docs dir if not present
-  if (!file.exists("docs")) {
+  if (dirname(out_path) == 'docs' & !file.exists("docs")) {
     dir.create("docs")
   }
 

--- a/R/edit_file.R
+++ b/R/edit_file.R
@@ -17,7 +17,7 @@
 #' # Specifying a different dataspice metadata directory
 #' edit_attributes(metadata_dir = "analysis/data/metadata/"))
 #'}
-edit_attributes <- function(metadata_dir = "data/metadata") {
+edit_attributes <- function(metadata_dir = file.path("data", "metadata")) {
   edit_file(metadata_dir, "attributes.csv")
 }
 
@@ -42,7 +42,7 @@ edit_creators <- function(metadata_dir = file.path("data", "metadata")) {
 
 # Shiny apps for editing dataspice metadata tables
 #' @importFrom dplyr "%>%"
-edit_file <- function(metadata_dir = "data/metadata", file) {
+edit_file <- function(metadata_dir = file.path("data", "metadata"), file) {
 
   filepath <- file.path(metadata_dir, file)
 

--- a/R/prep_access.R
+++ b/R/prep_access.R
@@ -25,7 +25,7 @@
 #' prep_access()
 #' }
 prep_access <- function(data_path = "data",
-                        access_path = "data/metadata/access.csv",
+                        access_path = file.path("data", "metadata", "access.csv"),
                                                  ...) {
   # check and load attributes
   if(!file.exists(access_path)) {

--- a/R/prep_attributes.R
+++ b/R/prep_attributes.R
@@ -42,7 +42,7 @@
 #' prep_attributes(data_path)
 #' }
 prep_attributes <- function(data_path = "data",
-                            attributes_path = "data/metadata/attributes.csv",
+                            attributes_path = file.path("data", "metadata", "attributes.csv"),
                             ...) {
   # list and validate file paths
   file_paths <- validate_file_paths(data_path, ...)

--- a/R/write_spice.R
+++ b/R/write_spice.R
@@ -20,7 +20,7 @@
 #' # Then write out your dataspice file
 #' write_spice()
 #' }
-write_spice <- function(path = "data/metadata", ...) {
+write_spice <- function(path = file.path("data", "metadata"), ...) {
 
   biblio <- readr::read_csv(
     file.path(path, "biblio.csv"),

--- a/man/build_site.Rd
+++ b/man/build_site.Rd
@@ -5,9 +5,9 @@
 \title{Build a dataspice site}
 \usage{
 build_site(
-  path = "data/metadata/dataspice.json",
+  path = file.path("data", "metadata", "dataspice.json"),
   template_path = system.file("template.html5", package = "dataspice"),
-  out_path = "docs/index.html"
+  out_path = file.path("docs", "index.html")
 )
 }
 \arguments{

--- a/man/edit_attributes.Rd
+++ b/man/edit_attributes.Rd
@@ -4,7 +4,7 @@
 \alias{edit_attributes}
 \title{Shiny apps for editing dataspice metadata tables}
 \usage{
-edit_attributes(metadata_dir = "data/metadata")
+edit_attributes(metadata_dir = file.path("data", "metadata"))
 }
 \arguments{
 \item{metadata_dir}{the directory containing the \code{dataspice} metadata \code{.csv}

--- a/man/prep_access.Rd
+++ b/man/prep_access.Rd
@@ -4,7 +4,11 @@
 \alias{prep_access}
 \title{Prepare access}
 \usage{
-prep_access(data_path = "data", access_path = "data/metadata/access.csv", ...)
+prep_access(
+  data_path = "data",
+  access_path = file.path("data", "metadata", "access.csv"),
+  ...
+)
 }
 \arguments{
 \item{data_path}{character vector of either:

--- a/man/prep_attributes.Rd
+++ b/man/prep_attributes.Rd
@@ -6,7 +6,7 @@
 \usage{
 prep_attributes(
   data_path = "data",
-  attributes_path = "data/metadata/attributes.csv",
+  attributes_path = file.path("data", "metadata", "attributes.csv"),
   ...
 )
 }

--- a/man/write_spice.Rd
+++ b/man/write_spice.Rd
@@ -4,7 +4,7 @@
 \alias{write_spice}
 \title{Write spice}
 \usage{
-write_spice(path = "data/metadata", ...)
+write_spice(path = file.path("data", "metadata"), ...)
 }
 \arguments{
 \item{path}{location of metadata files}


### PR DESCRIPTION
Just noticed there were some inconsistencies in using `file.path` across functions, sometimes for the same input (eg. the "metadata_dir" arg)